### PR TITLE
Removed rand_crypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sss-rs"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Aaron Flores <aaronjflores962@gmail.com"]
 edition = "2018"
 description = "A secret sharing scheme implemented in Rust"
@@ -19,7 +19,7 @@ rand = "0.7.2"
 lazy_static = "1.3.0"
 num-traits = "0.2.8"
 primal-check = "0.2.3"
-rust-crypto = "0.2.36"
+sha3 = "0.9.1"
 rand_chacha = "0.2.1"
 hex = "0.4.0"
 env_logger = "0.7.0"


### PR DESCRIPTION
Removed the dependency [rand_crypto](https://crates.io/crates/rust-crypto) in favor of the still maintained and more secure [sha3](https://crates.io/crates/sha3) crate.
This is not really optional, as this dependency is **very** insecure. Even when this crate was written, this was probably not an ideal choice. This is the entry in the Rust Sec Database: https://rustsec.org/advisories/RUSTSEC-2016-0005
