### PR TITLE
Feature/basic sharing parallelization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = "1.3.0"
 sha3 = "0.10.6"
 hex = "0.4.3"
 galois_2p8 = "0.1.2"
+rayon = "1.7.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,21 @@ lazy_static = "1.3.0"
 sha3 = "0.10.6"
 hex = "0.4.3"
 galois_2p8 = "0.1.2"
-rayon = "1.7.0"
+rayon = { version = "1.7.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
+tempfile = "3.6.0"
+
+[features]
+default = ["rayon"]
+rayon = ["dep:rayon"]
+wrapped_sharing_bench_use_disk_io = []
 
 [[bench]]
 name = "basic_sharing"
+harness = false
+
+[[bench]]
+name = "wrapped_sharing"
 harness = false

--- a/benches/wrapped_sharing.rs
+++ b/benches/wrapped_sharing.rs
@@ -1,0 +1,118 @@
+use rand::{thread_rng, Rng};
+use sss_rs::wrapped_sharing::{Sharer, Reconstructor};
+use std::io::{Cursor, Seek};
+
+#[cfg(wrapped_sharing_bench_use_disk_io)]
+use tempfile::tempfile;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+#[cfg(wrapped_sharing_bench_use_disk_io)]
+fn get_writable() -> File {
+    tempfile().unwrap()
+}
+
+#[cfg(not(wrapped_sharing_bench_use_disk_io))]
+fn get_writable() -> Cursor<Vec<u8>> {
+    Cursor::new(Vec::new())
+}
+
+macro_rules! share_func {
+    ($c:ident, $size:expr, $chunk_size:expr, $shares_required:literal, $shares_to_create:literal) => {{
+        let mut bytes = Vec::with_capacity($size);
+        unsafe { bytes.set_len($size) }; // For quicker setup for tests.
+        thread_rng().fill(bytes.as_mut_slice());
+
+        let mut dest1 = get_writable(); 
+        let mut dest2 = get_writable();
+        let byte_chunks = bytes.chunks($chunk_size).collect::<Vec<&[u8]>>();
+        $c.bench_function(
+            &format!(
+                "wrapped_sharing_{}byte_{}chunksize_{}_{}",
+                $size, $chunk_size, $shares_required, $shares_to_create
+            ),
+            |b| {
+                b.iter(|| {
+                    let mut sharer = Sharer::builder()
+                        .with_shares_required(2)
+                        .with_output(&mut dest1)
+                        .with_output(&mut dest2)
+                        .with_verify(true)
+                        .build()
+                        .unwrap();
+
+                    for secret in byte_chunks.iter() {
+                        sharer.update(secret).unwrap();
+                    }
+                    sharer.finalize().unwrap();
+                });
+                dest1.rewind().unwrap();
+                dest2.rewind().unwrap();
+            },
+        );
+    }};
+}
+macro_rules! reconstruct_func {
+    ($c:ident, $size:expr, $chunk_size:expr, $shares_required:literal, $shares_to_create:literal) => {{
+        let mut bytes = Vec::with_capacity($size);
+        unsafe { bytes.set_len($size) }; // For quicker setup for tests.
+        thread_rng().fill(bytes.as_mut_slice());
+        let mut dest1 = Cursor::new(Vec::new());
+        let mut dest2 = Cursor::new(Vec::new());
+        let byte_chunks = bytes.chunks($chunk_size).collect::<Vec<&[u8]>>();
+
+
+        let mut recon_dest = get_writable(); 
+       
+        let mut sharer = Sharer::builder()
+            .with_shares_required(2)
+            .with_output(&mut dest1)
+            .with_output(&mut dest2)
+            .with_verify(true)
+            .build()
+            .unwrap();
+       
+        for secret in byte_chunks.iter() {
+            sharer.update(secret).unwrap();
+        }
+        sharer.finalize().unwrap();
+
+
+        $c.bench_function(
+            &format!(
+                "wrapped_reconstruction_{}byte_{}chunksize_{}_{}",
+                $size, $chunk_size, $shares_required, $shares_to_create
+            ),
+            |b| {
+
+                b.iter(|| {
+                    let mut reconstructor = Reconstructor::new(&mut recon_dest, true);
+
+                    for (chunk1, chunk2) in dest1
+                        .get_ref()
+                        .chunks($chunk_size)
+                        .zip(dest2.get_ref().chunks($chunk_size)) 
+                    {
+                        reconstructor.update(&[chunk1, chunk2]).unwrap();
+                    }
+                    reconstructor.finalize().unwrap();
+                });
+                recon_dest.rewind().unwrap();
+            }
+        );
+    }};
+}
+
+fn wrapped_sharing(c: &mut Criterion) {
+    share_func!(c, 1 << 18, 1 << 13, 2, 2);
+    share_func!(c, 1 << 22, 1 << 13, 2, 2);
+
+
+    reconstruct_func!(c, 1 << 18, 1 << 13, 2, 2);
+    reconstruct_func!(c, 1 << 22, 1 << 13, 2, 2);
+
+
+}
+
+criterion_group!(benches, wrapped_sharing);
+criterion_main!(benches);

--- a/src/basic_sharing.rs
+++ b/src/basic_sharing.rs
@@ -6,8 +6,8 @@ use rand::{Rng, RngCore, SeedableRng};
 use rayon::prelude::*;
 use std::mem::transmute;
 
-const PAR_CUTOFF_SHARING: usize = 1280;
-const PAR_CUTOFF_RECON: usize = 1024;
+const PAR_CUTOFF_SHARING: usize = 4096;
+const PAR_CUTOFF_RECON: usize = 4096;
 
 /// Creates a vector of points that serve as the list of shares for a given byte of data.
 ///

--- a/src/basic_sharing.rs
+++ b/src/basic_sharing.rs
@@ -3,10 +3,15 @@
 use crate::geometry::{Coeff, GaloisPolynomial};
 use rand::rngs::StdRng;
 use rand::{Rng, RngCore, SeedableRng};
+#[cfg(feature = "rayon")]
 use rayon::prelude::*;
+
 use std::mem::transmute;
 
+#[cfg(feature = "rayon")]
 const PAR_CUTOFF_SHARING: usize = 4096;
+
+#[cfg(feature = "rayon")]
 const PAR_CUTOFF_RECON: usize = 4096;
 
 /// Creates a vector of points that serve as the list of shares for a given byte of data.

--- a/src/basic_sharing.rs
+++ b/src/basic_sharing.rs
@@ -4,6 +4,7 @@ use crate::geometry::{Coeff, GaloisPolynomial};
 use rand::rngs::StdRng;
 use rand::{Rng, RngCore, SeedableRng};
 use rayon::prelude::*;
+use std::mem::transmute;
 
 /// Creates a vector of points that serve as the list of shares for a given byte of data.
 ///
@@ -83,13 +84,13 @@ pub fn reconstruct_secrets<U: AsRef<[(u8, u8)]> + Sync + Send, T: AsRef<[U]> + S
 
 
     // Shhhhh pretend you didn't see this. (Safe bc it's just a ptr <--> isize conversion.) 
-    let result_ptr: isize = unsafe { std::mem::transmute(result.as_mut_ptr()) };
+    let result_ptr: isize = unsafe { transmute(result.as_mut_ptr()) };
 
     let recon_iter = |idx: usize| {
         unsafe {
             // SHHHHHHHHHH it's okay I PROMISE.
             // (Safe bc it is guaranteed that no thread will write to the same address.) 
-            std::mem::transmute::<isize, *mut u8>(result_ptr).add(idx).write(reconstruct_secret(
+            transmute::<isize, *mut u8>(result_ptr).add(idx).write(reconstruct_secret(
                 share_lists
                     .iter()
                     .map(|s| s.as_ref()[idx])
@@ -147,26 +148,55 @@ pub fn from_secrets_compressed<T: AsRef<[u8]>>(
         None => Box::new(StdRng::from_entropy()),
     };
 
-    // Create the vecs
+    // Pre-generate the coefficients together so we can avoid sending dyn RngCore between threads.
+    // This is probably more efficient than the (secret.len() * shares_to_create) calls to rng.gen().
+    let mut coeffs: Vec<u8> = Vec::with_capacity(secret.len() * shares_to_create as usize);
+    
+    // This is safe bc rng.fill() will write to every index and we are setting the len to the
+    // exact capacity we set prior.
+    //
+    // This is more efficient than doing secret.len() * shares_to_create loops of
+    // rng.gen().
+    unsafe { coeffs.set_len(secret.len() * shares_to_create as usize) };
+    rng.fill(coeffs.as_mut_slice());
+
+    // Create the vecs for each share.
     let mut shares_list = (0..shares_to_create)
         .map(|_| Vec::with_capacity(secret.len() + 1))
         .enumerate()
         .map(|(i, mut v)| {
-            v.push((i + 1) as u8); // This is the x coefficent of each share.
+            // This is safe bc we are guaranteed to write to every index and the len we are 
+            // setting is the exact capacity we just set prior.
+            unsafe { v.set_len(secret.len() + 1) };
+            v[0] = (i as u8) + 1; // This is the x coefficient of each share
             v
         })
         .collect::<Vec<Vec<u8>>>();
-    for s in secret {
+
+    // Need to send the ptr between threads which is safe here since we guarantee
+    // that no two threads will read nor write to the same index.
+    let shares_list_ptr: isize = unsafe { transmute(shares_list.as_mut_ptr()) };
+    secret
+        .par_iter()
+        .enumerate()
+        .for_each(|(idx, s)| {
         let mut share_poly = GaloisPolynomial::new();
         share_poly.set_coeff(Coeff(*s), 0);
-        for i in 1..shares_required {
-            let curr_co = rng.gen_range(2..255);
-            share_poly.set_coeff(Coeff(curr_co), i as usize);
+        for i in 1..(shares_required as usize) {
+            let curr_co = coeffs[(idx * i) + i];
+            share_poly.set_coeff(Coeff(curr_co), i);
         }
         for x in 0..shares_to_create {
-            shares_list[x as usize].push(share_poly.get_y_value(x + 1))    
+            // The following is safe bc we guarantee that no two threads will read nor write 
+            // to the same index.
+            unsafe {
+                transmute::<isize, *mut Vec<u8>>(shares_list_ptr)
+                    .add(x as usize)
+                    .as_mut()
+                    .unwrap()[idx + 1] = share_poly.get_y_value(x + 1);
+            }
         }
-    }
+    });
     Ok(shares_list)
 }
 

--- a/src/basic_sharing.rs
+++ b/src/basic_sharing.rs
@@ -104,7 +104,8 @@ pub fn reconstruct_secrets<U: AsRef<[(u8, u8)]> + Sync + Send, T: AsRef<[U]> + S
                 ));
         }
     };
-
+    
+    #[cfg(feature = "rayon")]
     if len < PAR_CUTOFF_RECON {
         // This is the cutoff point where parallelization overhead exceeds the performance gain
         // from the paralleization.
@@ -112,6 +113,8 @@ pub fn reconstruct_secrets<U: AsRef<[(u8, u8)]> + Sync + Send, T: AsRef<[U]> + S
     } else {
         (0..len).into_par_iter().for_each(recon_iter);
     }
+    #[cfg(not(feature = "rayon"))]
+    (0..len).for_each(recon_iter);
 
     result
 }
@@ -199,12 +202,18 @@ pub fn from_secrets_compressed<T: AsRef<[u8]>>(
             }
         }
     };
+
+    #[cfg(feature = "rayon")]
     if secret.len() < PAR_CUTOFF_SHARING { 
         secret.iter().enumerate().for_each(share_iter);
     }
     else {
         secret.par_iter().enumerate().for_each(share_iter);
     }
+    #[cfg(not(feature = "rayon"))]
+    secret.iter().enumerate().for_each(share_iter);
+    
+
     Ok(shares_list)
 }
 


### PR DESCRIPTION
Some additional optimizations, comparing this to 0.10.1 with the same benches is mind boggling. I don't think it showcases how great these optimizations are as much as it shows how so very poorly un-optimized my initial code was, I was a Rust baby at the time so I can forgive myself for that. 

## basic_sharing
- Add rayon-based parallelization for both sharing and reconstructing
- Improve coefficient generation by only sampling the Rng once rather than once for every byte.

## Todo
- [x] Make a feature for parallelization that will enable/disable the parallelization and add/remove the rayon dependency. 
- [x] I realize the cutoffs I implemented after lots of benching are probably fine tuned to my machine specifically, I'm sure different machines with CPU speeds and core counts will have different tuning. Not sure how much, but will test on the few devices I do have and see what the fluctuations are like. 