### PR TITLE
Replace sequentially generated x-values with random ones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rayon = { version = "1.7.0", optional = true }
 [dev-dependencies]
 criterion = "0.5.1"
 tempfile = "3.6.0"
+itertools = "0.14.0"
 
 [features]
 default = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rayon = { version = "1.7.0", optional = true }
 criterion = "0.5.1"
 tempfile = "3.6.0"
 itertools = "0.14.0"
+thiserror = "2.0.12"
 
 [features]
 default = ["rayon"]

--- a/src/basic_sharing.rs
+++ b/src/basic_sharing.rs
@@ -261,7 +261,7 @@ pub fn from_secrets_compressed<T: AsRef<[u8]>>(
         rng = &mut std_rng;
     };
 
-    let x_values = rand::seq::index::sample(rng, 254, shares_to_create as usize)
+    let x_values = rand::seq::index::sample(rng, 255, shares_to_create as usize)
         .iter()
         .map(|v| v as u8 + 1) // +1 here since sample includes 0 and we don't want 0.
         .collect::<Vec<u8>>();
@@ -346,7 +346,7 @@ mod tests {
     }
     #[test]
     fn singe_value_max_shares() {
-        basic_single_value(78, 254, 254);
+        basic_single_value(78, 255, 255);
     }
 
     fn basic_single_value(secret: u8, shares_to_create: u8, shares_required: u8) {
@@ -388,7 +388,7 @@ mod tests {
     #[test]
     fn compressed_max_shares() {
         let secret = vec![10, 20, 30, 40, 50];
-        let n = 254;
+        let n = 255;
         let shares = from_secrets_compressed(&secret, n, n, None).unwrap();
         let recon = reconstruct_secrets_compressed(shares).unwrap();
         assert_eq!(secret, recon);

--- a/src/basic_sharing.rs
+++ b/src/basic_sharing.rs
@@ -2,7 +2,7 @@
 //! should be utilized, otherwise these functions are useful for implementing a custom abstraction/wrapper.
 use crate::geometry::{Coeff, GaloisPolynomial};
 use rand::rngs::StdRng;
-use rand::{Rng, RngCore, SeedableRng};
+use rand::{seq::SliceRandom, Rng, RngCore, SeedableRng};
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
@@ -128,6 +128,96 @@ pub fn reconstruct_secrets<U: AsRef<[(u8, u8)]> + Sync + Send, T: AsRef<[U]> + S
     Ok(result)
 }
 
+pub(crate) fn from_secrets_compressed_inner<T: AsRef<[u8]>, U: AsRef<[u8]>>(
+    secret: T,
+    shares_required: u8,
+    x_values: U,
+    rand: Option<&mut dyn RngCore>,
+) -> Result<Vec<Vec<u8>>, Error> {
+    let secret = secret.as_ref();
+    let shares_to_create = x_values.as_ref().len() as u8;
+
+    if shares_required > shares_to_create {
+        return Err(Error::UnreconstructableSecret(
+            shares_to_create,
+            shares_required,
+        ));
+    }
+
+    if shares_to_create == 0 {
+        return Err(Error::InvalidNumberOfShares);
+    }
+
+    let mut rng: Box<dyn RngCore> = match rand {
+        Some(rng) => Box::new(rng),
+        None => Box::new(StdRng::from_entropy()),
+    };
+
+    // Pre-generate the coefficients together so we can avoid sending dyn RngCore between threads.
+    // This is probably more efficient than the (secret.len() * shares_to_create) calls to rng.gen().
+    let mut coeffs: Vec<u8> = Vec::with_capacity(secret.len() * shares_to_create as usize);
+
+    // This is safe bc rng.fill() will write to every index and we are setting the len to the
+    // exact capacity we set prior.
+    //
+    // This is more efficient than doing secret.len() * shares_to_create loops of
+    // rng.gen().
+    unsafe { coeffs.set_len(secret.len() * shares_to_create as usize) };
+    rng.fill(coeffs.as_mut_slice());
+
+    // Create the vecs for each share.
+    let mut shares_list = x_values
+        .as_ref()
+        .iter()
+        .map(|x_value| (x_value, Vec::with_capacity(secret.len() + 1)))
+        .map(|(x_value, mut v)| {
+            // Unwrap is safe here since we have already ensured shares_to_create <= 255.
+
+            // This is safe bc we are guaranteed to write to every index and the len we are
+            // setting is the exact capacity we just set prior.
+            unsafe { v.set_len(secret.len() + 1) };
+            v[0] = *x_value; // This is the x coefficient of each share
+            v
+        })
+        .collect::<Vec<Vec<u8>>>();
+
+    // Need to send the ptr between threads which is safe here since we guarantee
+    // that no two threads will read nor write to the same index.
+    let shares_list_ptr: isize = unsafe { transmute(shares_list.as_mut_ptr()) };
+
+    let share_iter = |(byte_idx, s): (usize, &u8)| {
+        let mut share_poly = GaloisPolynomial::new();
+        share_poly.set_coeff(Coeff(*s), 0);
+        for i in 1..(shares_required as usize) {
+            let curr_co = coeffs[(byte_idx * i) + i];
+            share_poly.set_coeff(Coeff(curr_co), i);
+        }
+        for share_idx in 0..shares_to_create {
+            // The following is safe bc we guarantee that no two threads will read nor write
+            // to the same index.
+            unsafe {
+                let share_list = transmute::<isize, *mut Vec<u8>>(shares_list_ptr)
+                    .add(share_idx as usize)
+                    .as_mut()
+                    .unwrap();
+                let x = share_list[0];
+                share_list[byte_idx + 1] = share_poly.get_y_value(x);
+            }
+        }
+    };
+
+    #[cfg(feature = "rayon")]
+    if secret.len() < PAR_CUTOFF_SHARING {
+        secret.iter().enumerate().for_each(share_iter);
+    } else {
+        secret.par_iter().enumerate().for_each(share_iter);
+    }
+    #[cfg(not(feature = "rayon"))]
+    secret.iter().enumerate().for_each(share_iter);
+
+    Ok(shares_list)
+}
+
 /// Wrapper around its corresponding share function but deduplicates the x-value
 /// from all the points to reduce the size of the share.
 ///
@@ -158,69 +248,21 @@ pub fn from_secrets_compressed<T: AsRef<[u8]>>(
         return Err(Error::InvalidNumberOfShares);
     }
 
-    let mut rng: Box<dyn RngCore> = match rand {
-        Some(rng) => Box::new(rng),
-        None => Box::new(StdRng::from_entropy()),
-    };
+    let mut all_x_values = (1u8..255).collect::<Vec<u8>>();
 
-    // Pre-generate the coefficients together so we can avoid sending dyn RngCore between threads.
-    // This is probably more efficient than the (secret.len() * shares_to_create) calls to rng.gen().
-    let mut coeffs: Vec<u8> = Vec::with_capacity(secret.len() * shares_to_create as usize);
+    // Due to borrowing rules and trying to avoid a signature change,
+    // we have to initialize this here so we can pass it as a reference
+    // for when rand is None.
+    let mut std_rng = StdRng::from_entropy();
 
-    // This is safe bc rng.fill() will write to every index and we are setting the len to the
-    // exact capacity we set prior.
-    //
-    // This is more efficient than doing secret.len() * shares_to_create loops of
-    // rng.gen().
-    unsafe { coeffs.set_len(secret.len() * shares_to_create as usize) };
-    rng.fill(coeffs.as_mut_slice());
+    let rng = rand.or_else(|| Some(&mut std_rng)).unwrap();
+    all_x_values.shuffle(rng);
 
-    // Create the vecs for each share.
-    let mut shares_list = (0..shares_to_create)
-        .map(|_| Vec::with_capacity(secret.len() + 1))
-        .enumerate()
-        .map(|(i, mut v)| {
-            // This is safe bc we are guaranteed to write to every index and the len we are
-            // setting is the exact capacity we just set prior.
-            unsafe { v.set_len(secret.len() + 1) };
-            v[0] = (i as u8) + 1; // This is the x coefficient of each share
-            v
-        })
-        .collect::<Vec<Vec<u8>>>();
+    let x_values = (0..shares_to_create)
+        .map(|v| all_x_values[v as usize])
+        .collect::<Vec<u8>>();
 
-    // Need to send the ptr between threads which is safe here since we guarantee
-    // that no two threads will read nor write to the same index.
-    let shares_list_ptr: isize = unsafe { transmute(shares_list.as_mut_ptr()) };
-
-    let share_iter = |(idx, s): (usize, &u8)| {
-        let mut share_poly = GaloisPolynomial::new();
-        share_poly.set_coeff(Coeff(*s), 0);
-        for i in 1..(shares_required as usize) {
-            let curr_co = coeffs[(idx * i) + i];
-            share_poly.set_coeff(Coeff(curr_co), i);
-        }
-        for x in 0..shares_to_create {
-            // The following is safe bc we guarantee that no two threads will read nor write
-            // to the same index.
-            unsafe {
-                transmute::<isize, *mut Vec<u8>>(shares_list_ptr)
-                    .add(x as usize)
-                    .as_mut()
-                    .unwrap()[idx + 1] = share_poly.get_y_value(x + 1);
-            }
-        }
-    };
-
-    #[cfg(feature = "rayon")]
-    if secret.len() < PAR_CUTOFF_SHARING {
-        secret.iter().enumerate().for_each(share_iter);
-    } else {
-        secret.par_iter().enumerate().for_each(share_iter);
-    }
-    #[cfg(not(feature = "rayon"))]
-    secret.iter().enumerate().for_each(share_iter);
-
-    Ok(shares_list)
+    from_secrets_compressed_inner(secret, shares_required, x_values, Some(rng))
 }
 
 /// Wrapper around its [reconstruct_secrets], accepts shares created by [from_secrets_compressed]

--- a/src/basic_sharing.rs
+++ b/src/basic_sharing.rs
@@ -321,6 +321,7 @@ impl std::error::Error for Error {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use itertools::Itertools;
     use rand::rngs::StdRng;
     use rand::Rng;
     use rand::SeedableRng;
@@ -367,6 +368,20 @@ mod tests {
     }
 
     #[test]
+    fn all_combination_recon() {
+        let secret = vec![10, 20, 30, 40, 50];
+        let shares_required = 4;
+        let shares_to_create = 10;
+        let shares =
+            from_secrets_compressed(&secret, shares_required, shares_to_create, None).unwrap();
+
+        shares
+            .into_iter()
+            .combinations(shares_required as usize)
+            .for_each(|shares| assert_eq!(secret, reconstruct_secrets_compressed(shares).unwrap()));
+    }
+
+    #[test]
     fn compressed_max_shares() {
         let secret = vec![10, 20, 30, 40, 50];
         let n = 254;
@@ -398,8 +413,10 @@ mod tests {
         let cre = 8;
         let shares = from_secrets_compressed(&secret, req, cre, None).unwrap();
 
-        let recon = reconstruct_secrets_compressed(&shares[0..6]).unwrap();
-        assert_eq!(secret, recon);
+        for count in req..=cre {
+            let recon = reconstruct_secrets_compressed(&shares[0..(count as usize)]).unwrap();
+            assert_eq!(secret, recon);
+        }
     }
 
     // Technically pointless since the created share is just the secret, but this bound

--- a/src/basic_sharing.rs
+++ b/src/basic_sharing.rs
@@ -339,6 +339,10 @@ mod tests {
             basic_single_value(secret, shares_to_create, shares_required);
         }
     }
+    #[test]
+    fn singe_value_max_shares() {
+        basic_single_value(78, 254, 254);
+    }
 
     fn basic_single_value(secret: u8, shares_to_create: u8, shares_required: u8) {
         /* Was used to find an infinite loop, no longer needed, but keeping for future reference
@@ -356,7 +360,16 @@ mod tests {
     #[test]
     fn compressed() {
         let secret = vec![10, 20, 30, 40, 50];
-        let n = 3;
+        let n = 5;
+        let shares = from_secrets_compressed(&secret, n, n, None).unwrap();
+        let recon = reconstruct_secrets_compressed(shares).unwrap();
+        assert_eq!(secret, recon);
+    }
+
+    #[test]
+    fn compressed_max_shares() {
+        let secret = vec![10, 20, 30, 40, 50];
+        let n = 254;
         let shares = from_secrets_compressed(&secret, n, n, None).unwrap();
         let recon = reconstruct_secrets_compressed(shares).unwrap();
         assert_eq!(secret, recon);

--- a/src/basic_sharing.rs
+++ b/src/basic_sharing.rs
@@ -124,7 +124,6 @@ pub fn reconstruct_secrets<U: AsRef<[(u8, u8)]> + Sync + Send, T: AsRef<[U]> + S
     }
     #[cfg(not(feature = "rayon"))]
     (0..len).for_each(recon_iter);
-
     Ok(result)
 }
 
@@ -296,7 +295,7 @@ fn expand_share<T: AsRef<[u8]>>(share: T) -> Vec<(u8, u8)> {
     share[1..].iter().map(|y| (x_value, *y)).collect()
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Error {
     /// shares_required was < 2
     InvalidNumberOfShares,

--- a/src/fuzz_tests.rs
+++ b/src/fuzz_tests.rs
@@ -4,7 +4,7 @@ use rand::{seq::SliceRandom, thread_rng, Rng};
 
 const FUZZ_COUNT: usize = 100_000;
 const SECRET_LEN_MIN: usize = 0;
-const SECRET_LEN_MAX: usize = 1;
+const SECRET_LEN_MAX: usize = 10000;
 
 #[test]
 fn fuzz_basic_sharing() {
@@ -26,7 +26,7 @@ fn fuzz_basic_sharing() {
 
         let selected_shares = &shares[0..shares_to_use_for_recon];
 
-        let recon_secret = reconstruct_secrets_compressed(selected_shares);
+        let recon_secret = reconstruct_secrets_compressed(selected_shares).unwrap();
         assert_eq!(secret, recon_secret);
     }
 }

--- a/src/fuzz_tests.rs
+++ b/src/fuzz_tests.rs
@@ -4,9 +4,9 @@ use thiserror::Error;
 
 use rand::{seq::SliceRandom, thread_rng, Rng};
 
-const FUZZ_COUNT: usize = 100_000;
+const FUZZ_COUNT: usize = 100_00;
 const SECRET_LEN_MIN: usize = 0;
-const SECRET_LEN_MAX: usize = 10000;
+const SECRET_LEN_MAX: usize = 64;
 
 #[test]
 fn fuzz_basic_sharing() {
@@ -58,7 +58,7 @@ impl<E: Error + Clone + std::fmt::Debug + std::fmt::Display> FuzzTestInfo<E> {
 
 #[test]
 fn fuzz_all_combinations_max_shares() {
-    let secret_len = 64;
+    let secret_len = 16;
     let mut secret = Vec::with_capacity(secret_len);
     unsafe {
         secret.set_len(secret_len);

--- a/src/fuzz_tests.rs
+++ b/src/fuzz_tests.rs
@@ -1,4 +1,6 @@
-use crate::basic_sharing::*;
+use crate::basic_sharing::{from_secrets_compressed, reconstruct_secrets_compressed};
+use std::error::Error;
+use thiserror::Error;
 
 use rand::{seq::SliceRandom, thread_rng, Rng};
 
@@ -17,6 +19,9 @@ fn fuzz_basic_sharing() {
             thread_rng().gen_range(shares_required..=shares_to_create) as usize;
 
         let mut secret: Vec<u8> = Vec::with_capacity(secret_len);
+        unsafe {
+            secret.set_len(secret_len);
+        }
         thread_rng().fill(secret.as_mut_slice());
 
         let mut shares =
@@ -28,5 +33,86 @@ fn fuzz_basic_sharing() {
 
         let recon_secret = reconstruct_secrets_compressed(selected_shares).unwrap();
         assert_eq!(secret, recon_secret);
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Error)]
+pub struct FuzzTestInfo<E: Error> {
+    pub secret: String,
+    pub shares_to_create: u8,
+    pub shares_required: u8,
+    pub num_shares_attempted_for_recon: Option<u8>,
+    pub recon_secret: Option<String>,
+
+    #[source]
+    pub source: Option<E>,
+}
+
+impl<E: Error + Clone + std::fmt::Debug + std::fmt::Display> FuzzTestInfo<E> {
+    fn with_source(mut self, source: E) -> Self {
+        self.source = Some(source);
+        self
+    }
+}
+
+#[test]
+fn fuzz_all_combinations_max_shares() {
+    let secret_len = 64;
+    let mut secret = Vec::with_capacity(secret_len);
+    unsafe {
+        secret.set_len(secret_len);
+    }
+    thread_rng().fill(secret.as_mut_slice());
+
+    let n = 255;
+    let initial_required = 2;
+
+    for shares_required in initial_required..n {
+        let mut fuzz_test_info = FuzzTestInfo {
+            secret: hex::encode(&secret),
+            shares_to_create: 255,
+            shares_required,
+            num_shares_attempted_for_recon: None,
+            recon_secret: None,
+            source: None,
+        };
+
+        let shares = from_secrets_compressed(secret.as_slice(), shares_required, n, None)
+            .map_err(|e| fuzz_test_info.clone().with_source(e))
+            .unwrap();
+
+        /*shares
+            .into_iter()
+            .combinations(shares_required as usize)
+            .for_each(|shares| {
+                match reconstruct_secrets_compressed(shares) {
+                    Ok(recon_secret) => {
+
+                    }
+                }
+                assert_eq!(&secret, &reconstruct_secrets_compressed(shares).unwrap())
+
+            });
+
+        Leaving this here so I never forget how horrific of a mistake this was.
+        I mean it's only
+        57896044618658097711785492504343953926634992332820282019728792003956564819711
+        iterations, how long could that take? :)
+
+        */
+
+        for num_shares_for_recon in shares_required..n {
+            fuzz_test_info.num_shares_attempted_for_recon = Some(num_shares_for_recon);
+            let recon_secret =
+                reconstruct_secrets_compressed(&shares[0..(num_shares_for_recon as usize)])
+                    .map_err(|e| fuzz_test_info.clone().with_source(e))
+                    .unwrap();
+            fuzz_test_info.recon_secret = Some(hex::encode(&recon_secret));
+
+            if &recon_secret != &secret {
+                panic!("{:?}", fuzz_test_info);
+            }
+        }
     }
 }

--- a/src/wrapped_sharing.rs
+++ b/src/wrapped_sharing.rs
@@ -669,12 +669,27 @@ mod tests {
     }
 
     #[test]
+    fn equal_shares_create_and_required() {
+        let secret = vec![10, 20, 30, 50];
+        let num_shares = 5;
+        let num_shares_required = 5;
+        let shares = share(&secret, num_shares_required, num_shares, true).unwrap();
+        let recon_secret = reconstruct(&shares[0..3], true).unwrap();
+
+        assert_eq!(secret, recon_secret);
+    }
+
+    #[test]
     fn max_shares_create() {
         let secret = vec![10, 20, 30, 50];
         let num_shares = 255;
         let num_shares_required = 3;
         let shares = share(&secret, num_shares_required, num_shares, true).unwrap();
         let recon_secret = reconstruct(&shares[0..3], true).unwrap();
+
+        assert_eq!(secret, recon_secret);
+
+        let recon_secret = reconstruct(&shares[252..255], true).unwrap();
 
         assert_eq!(secret, recon_secret);
     }

--- a/src/wrapped_sharing.rs
+++ b/src/wrapped_sharing.rs
@@ -483,7 +483,7 @@ pub fn reconstruct_buffered_dyn<'a, T: Write, U: AsMut<[Box<dyn Read + 'a>]> + '
     verify: bool,
     buf_size: Option<usize>,
 ) -> Result<u64, Error> {
-    // We can either require AsMut, or IntoIterator here. Unusre of which is most 
+    // We can either require AsMut, or IntoIterator here. Unusre of which is most
     // flexible for expected uses cases. We cannot use AsRef here bc Read is not
     // implemented for &Box<dyn Read>.
     let mut reconstructor = Reconstructor::new(secret_dest, verify);

--- a/src/wrapped_sharing.rs
+++ b/src/wrapped_sharing.rs
@@ -669,6 +669,28 @@ mod tests {
     }
 
     #[test]
+    fn max_shares_create() {
+        let secret = vec![10, 20, 30, 50];
+        let num_shares = 255;
+        let num_shares_required = 3;
+        let shares = share(&secret, num_shares_required, num_shares, true).unwrap();
+        let recon_secret = reconstruct(&shares[0..3], true).unwrap();
+
+        assert_eq!(secret, recon_secret);
+    }
+
+    #[test]
+    fn max_shares_create_and_required() {
+        let secret = vec![10, 20, 30, 50];
+        let num_shares = 255;
+        let num_shares_required = 255;
+        let shares = share(&secret, num_shares_required, num_shares, true).unwrap();
+        let recon_secret = reconstruct(&shares[0..3], true).unwrap();
+
+        assert_eq!(secret, recon_secret);
+    }
+
+    #[test]
     fn base_functions_no_verify() {
         let secret = vec![10, 20, 30, 50];
         let num_shares = 6;

--- a/src/wrapped_sharing.rs
+++ b/src/wrapped_sharing.rs
@@ -654,18 +654,31 @@ impl From<std::io::Error> for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use itertools::Itertools;
     use rand::{thread_rng, Rng};
     use std::io::{Cursor, Seek};
 
     #[test]
     fn base_functions() {
         let secret = vec![10, 20, 30, 50];
-        let num_shares = 6;
+        let num_shares = 3;
         let num_shares_required = 3;
         let shares = share(&secret, num_shares_required, num_shares, true).unwrap();
-        let recon_secret = reconstruct(&shares[0..3], true).unwrap();
-
+        let recon_secret = reconstruct(&shares, true).unwrap();
         assert_eq!(secret, recon_secret);
+    }
+
+    #[test]
+    fn all_combination_recon() {
+        let secret = vec![10, 20, 30, 50];
+        let num_shares = 7;
+        let num_shares_required = 3;
+        let shares = share(&secret, num_shares_required, num_shares, true).unwrap();
+
+        shares
+            .into_iter()
+            .combinations(3)
+            .for_each(|shares| assert_eq!(secret, reconstruct(&shares, true).unwrap()));
     }
 
     #[test]
@@ -674,7 +687,7 @@ mod tests {
         let num_shares = 5;
         let num_shares_required = 5;
         let shares = share(&secret, num_shares_required, num_shares, true).unwrap();
-        let recon_secret = reconstruct(&shares[0..3], true).unwrap();
+        let recon_secret = reconstruct(&shares, true).unwrap();
 
         assert_eq!(secret, recon_secret);
     }
@@ -700,7 +713,7 @@ mod tests {
         let num_shares = 255;
         let num_shares_required = 255;
         let shares = share(&secret, num_shares_required, num_shares, true).unwrap();
-        let recon_secret = reconstruct(&shares[0..3], true).unwrap();
+        let recon_secret = reconstruct(&shares, true).unwrap();
 
         assert_eq!(secret, recon_secret);
     }


### PR DESCRIPTION
Covers #24 

The public API remains unchanged, and this includes multiple additional unit tests for increased coverage. 

 - Adds `pub(crate) from_secrets_compressed_inner()` which `from_secrets_compressed()` now wraps around. 
   - This allows buffered sharing implementations to supply the x-values to use so each chunk can be generated with the same randomly generated x-value, rather than assuming a sequential x-value.
   - This keeps the signature for `from_secrets_compressed()` unchanged, and its functionality outside of the x-value change remains unchanged. Though it now itself utilizes randomly generated x-values. 
 - Additional unit tests to cover the following
   - Full combination coverage of generated shares, for example: We generated 8 shares, only 3 required for reconstruction. The tests will cover reconstruction of every unique combination of 3 shares to ensure they all correctly reconstruct the secret
   - Limit tests to cover generating 255 shares and requiring some smaller Y amount, and also generating 255 shares and requiring all 255 to reconstruct. 
 - Adds `itertools` as a dev dependency for tests. This greatly simplifies the combination testing mentioned above. 
 - Fixes missing `Result` handling in `fuzz_tests` only test, and adds an additional combination fuzz test. 


## TODO
 - [x] Now's a good a time as any to see if there's still any missing coverage in tests.